### PR TITLE
[tpu-mlir] new configuration option: "quant_input" "quant_output"

### DIFF
--- a/vision/classification/mobilenet-v2/config.yaml
+++ b/vision/classification/mobilenet-v2/config.yaml
@@ -36,6 +36,8 @@ deploy:
   - model_deploy.py --mlir $(workdir)/transformed.mlir
       --quantize INT8
       --calibration_table $(home)/cali_table
+      --quant_input
+      --quant_output
       --chip bm1684x
       --test_input $(workdir)/$(name)_in_f32.npz
       --test_reference $(name)_top_outputs.npz

--- a/vision/classification/resnet18-v2/config.yaml
+++ b/vision/classification/resnet18-v2/config.yaml
@@ -37,6 +37,8 @@ deploy:
   - model_deploy.py --mlir $(workdir)/transformed.mlir
       --quantize INT8
       --calibration_table $(home)/cali_table
+      --quant_input
+      --quant_output
       --chip bm1684x
       --test_input $(workdir)/$(name)_in_f32.npz
       --test_reference $(name)_top_outputs.npz

--- a/vision/classification/resnet50-v2/config.yaml
+++ b/vision/classification/resnet50-v2/config.yaml
@@ -37,6 +37,8 @@ deploy:
   - model_deploy.py --mlir $(workdir)/transformed.mlir
       --quantize INT8
       --calibration_table $(home)/cali_table
+      --quant_input
+      --quant_output
       --chip bm1684x
       --test_input $(workdir)/$(name)_in_f32.npz
       --test_reference $(name)_top_outputs.npz

--- a/vision/classification/squeezenet1.0/config.yaml
+++ b/vision/classification/squeezenet1.0/config.yaml
@@ -36,6 +36,8 @@ deploy:
   - model_deploy.py --mlir $(workdir)/transformed.mlir
       --quantize INT8
       --calibration_table $(home)/cali_table
+      --quant_input
+      --quant_output
       --chip bm1684x
       --test_input $(workdir)/$(name)_in_f32.npz
       --test_reference $(name)_top_outputs.npz

--- a/vision/classification/vgg16/config.yaml
+++ b/vision/classification/vgg16/config.yaml
@@ -36,6 +36,8 @@ deploy:
   - model_deploy.py --mlir $(workdir)/transformed.mlir
       --quantize INT8
       --calibration_table $(home)/cali_table
+      --quant_input
+      --quant_output
       --chip bm1684x
       --test_input $(workdir)/$(name)_in_f32.npz
       --test_reference $(name)_top_outputs.npz

--- a/vision/detection/yolov5/yolov5s.config.yaml
+++ b/vision/detection/yolov5/yolov5s.config.yaml
@@ -36,6 +36,8 @@ deploy:
   - model_deploy.py --mlir $(workdir)/transformed.mlir
       --quantize INT8
       --calibration_table $(home)/cali_table
+      --quant_input
+      --quant_output
       --chip bm1684x
       --test_input $(workdir)/$(name)_in_f32.npz
       --test_reference $(name)_top_outputs.npz


### PR DESCRIPTION
- remove input/output type cast in bmodel.