### PR TITLE
dbnet nntc(1684x fp32&int8) &mlir(1684x&1684 fp32)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,4 @@ dataset/ILSVRC2012/caffe_val.txt filter=lfs diff=lfs merge=lfs -text
 *.npy filter=lfs diff=lfs merge=lfs -text
 dataset/SQuAD/val/dev-v1.1.json filter=lfs diff=lfs merge=lfs -text
 *.pt-* filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ python3 .github/workflows/check.py
 |clip                             |[vision/classification/clip-mlir](vision/classification/clip-mlir)                                    |                    |:white\_check\_mark:|
 |CRNN                             |[vision/OCR/CRNN](vision/OCR/CRNN)                                                                    |:white\_check\_mark:|                    |
 |cyclegan\_horse2zebra            |[vision/GAN/cyclegan](vision/GAN/cyclegan)                                                            |:white\_check\_mark:|                    |
+|dbnet                            |[vision/detection/dbnet](vision/detection/dbnet)                                                      |:white\_check\_mark:|:white\_check\_mark:|
 |DBNet\_totaltext\_res18\_dcn     |[vision/OCR/DBNet](vision/OCR/DBNet)                                                                  |:white\_check\_mark:|                    |
 |DBNet\_totaltext\_res50\_dcn     |[vision/OCR/DBNet](vision/OCR/DBNet)                                                                  |:white\_check\_mark:|                    |
 |deeplabv3p                       |[vision/segmentation/deeplabv3p](vision/segmentation/deeplabv3p)                                      |:white\_check\_mark:|:white\_check\_mark:|

--- a/full_cases.txt
+++ b/full_cases.txt
@@ -114,3 +114,4 @@ vision/segmentation/BiSeNet
 vision/segmentation/SegFormer
 language/generative/gpt2
 vision/generative/stable_diffusion
+vision/detection/dbnet

--- a/vision/detection/dbnet/README.md
+++ b/vision/detection/dbnet/README.md
@@ -1,0 +1,34 @@
+<!--- SPDX-License-Identifier: Apache-2.0 -->
+
+# DBnet
+
+## Description
+
+This is a implementation of the Differentiable Binarization. And this model perform the binarization process in a segmentation network. We directly adapt the PaddleOCR version. And we adapt MobileNet-v2 as the backbone.
+
+
+## Model
+
+|Model(nntc)                |Model(dbnet)               |H1 Mean    |
+|---------------------------|---------------------------|-----------|
+|[dbnet.pdmodel](inference) |[dbnet.onnx](dbnet.onnx)   |68%        |
+
+You can use Paddle2Onnx to convert paddle-style model-storage to onnx-style.
+
+## Dataset
+
+We choose Task 4.1 in Incidental Scene Text Dataset icdar2015 as the benchmark. And we offer preprocessed data and groundtruth.
+
+## References
+
+* ["Real-time Scene Text Detection with Differentiable Binarization"](<https://arxiv.org/pdf/1911.08947.pdf>)
+
+* [PaddleOCR](<https://github.com/PaddlePaddle/PaddleOCR>)
+
+* [icdar2015](https://rrc.cvc.uab.es/?ch=4>)
+
+* [Task4_1]<https://rrc.cvc.uab.es/?ch=4&com=tasks>
+
+## License
+
+Apache-2.0

--- a/vision/detection/dbnet/data/icdar2015/ch4_quanti_data/img_1.jpg
+++ b/vision/detection/dbnet/data/icdar2015/ch4_quanti_data/img_1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da096cd77ec4a078636778809cd8e6f85cd4a942c3f99bacc4eceb2fedad13d0
+size 81873

--- a/vision/detection/dbnet/dbnet.mlir.config.yaml
+++ b/vision/detection/dbnet/dbnet.mlir.config.yaml
@@ -1,0 +1,46 @@
+---
+name: dbnet
+icdar_dataset: $(home)/data/icdar2015
+gops: [5.255]
+
+mlir_transform:
+  model_transform.py
+    --model_name $(name)
+    --model_def $(home)/$(name).onnx
+    --output_names="sigmoid_0.tmp_0"
+    --input_shapes="[[2,3,736,1280]]"
+    --mlir $(name).mlir
+    --mean 123.93,116.28,103.53
+    --scale 0.01712475383,0.0175070028,0.01742919389
+    --pixel_format rgb
+    --test_input $(icdar_dataset)/ch4_quanti_data/img_1.jpg
+    --test_result $(workdir)/$(name)_top_outputs.npz
+
+deploy:
+  - model_deploy.py
+     --mlir $(workdir)/$(name).mlir
+     --quantize F32
+     --chip $(target)
+     --test_input=$(workdir)/$(name)_in_f32.npz
+     --test_reference=$(workdir)/$(name)_top_outputs.npz
+     --tolerance 0.99,0.99
+     --model $(workdir)/$(name)_$(target)_f32.bmodel
+
+BM1684X:
+  +deploy:
+    - model_deploy.py
+        --mlir $(workdir)/$(name).mlir
+        --quantize F16
+        --chip bm1684x
+        --test_input=$(workdir)/$(name)_in_f32.npz
+        --test_reference=$(workdir)/$(name)_top_outputs.npz
+        --tolerance 0.95,0.85
+        --model $(workdir)/$(name)_bm1684x_f16.bmodel
+#   - model_deploy.py
+#     --mlir $(workdir)/$(name).mlir
+#     --quantize BF16
+#     --chip bm1684x
+#     --test_input=$(workdir)/$(name)_in_f32.npz
+#     --test_reference=$(workdir)/$(name)_top_outputs.npz
+#     --tolerance 0.93,0.65
+#     --model $(workdir)/$(name)_bm1684x_bf16.bmodel

--- a/vision/detection/dbnet/dbnet.nntc.config.yaml
+++ b/vision/detection/dbnet/dbnet.nntc.config.yaml
@@ -1,0 +1,62 @@
+---
+name: dbnet
+model: $(home)/inference
+dataset_path: $(home)/data/icdar2015
+output_path: $(root)/output/$(name)/inference
+time: true
+precision: true
+gops: [5.255]
+
+div_info: div=0.229:0.224:0.225
+mean_info: mean_value=0.485:0.456:0.406
+size_info: resize_h=736,resize_w=1280;scale=0.00392156862
+fp_batch_sizes: [1]
+
+fp_loops:
+  - build_env:
+      - BMCOMPILER_LAYER_DTYPE_MODE=
+    fp_outdir_template: "{}b.fp32.compilation"
+
+BM1684X:
+  fp_compile_options:
+    python3 -m bmpaddle
+        --model=$(model)
+        --shapes [4,3,736,1280]
+        --net_name $(name)
+        --target BM1684X
+        --cmp=False
+        --enable_profile True
+
+  #  time_only_cali:
+  #    python3 -u -m ufw.cali.cali_model
+  #      --net_name $(name)
+  #      --model $(model)/inference.pdmodel
+  #      --input_shapes [1,3,736,1280]
+  #    --cali_image_preprocess '$(size_info),$(mean_info),$(div_info),bgr2rgb=1'
+  #      --cali_image_path $(dataset_path)/ch4_quanti_data
+  #      --debug_cmd='to_umodel_not_cmp;quant_1684X;not_suspend;not_call_bmnetu'
+  #      --target=BM1684X
+  #      --cali_iterations 1
+  #      --test_iterations 1
+  #      --input_names "x"
+  #      --output_names "sigmoid_0.tmp_0"
+
+  #  bmnetu_batch_sizes: [1]
+
+  #  int8_model: $(workdir)/$(name)_bmpaddle_deploy_int8_unique_top.prototxt
+  #  int8_weight: $(workdir)/$(name)_bmpaddle.int8umodel
+
+  #  bmnetu_options:
+  #    --model $(int8_model)
+  #    --weight $(int8_weight)
+  #    --net_name $(name)
+  #    --target BM1684X
+  #    --cmp=False
+  #    --v=4
+  #    --opt 2
+  #    --output_as_fp32 sigmoid_0.tmp_0
+  #    --seed=42
+  #    --enable_profile=True
+
+  build_env:
+    - BMCOMPILER_EXPORT_GRAPH=1

--- a/vision/detection/dbnet/dbnet.onnx
+++ b/vision/detection/dbnet/dbnet.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b3d809ad794de0ad89ec705c0b38acd64bd0eaf3e31e12f02783215e1ba8059
+size 6833087

--- a/vision/detection/dbnet/inference/inference.pdiparams
+++ b/vision/detection/dbnet/inference/inference.pdiparams
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4327f6a90368d9f91a3ed0b183cc0cf3d533fd2d160f6419f26a0b0df1c0528b
+size 6776813

--- a/vision/detection/dbnet/inference/inference.pdiparams.info
+++ b/vision/detection/dbnet/inference/inference.pdiparams.info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:639d837ed5b33d8f58cbf4e18f42925473966ad3a1df494065dcb8ac826bb392
+size 26308

--- a/vision/detection/dbnet/inference/inference.pdmodel
+++ b/vision/detection/dbnet/inference/inference.pdmodel
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f04d6f3b08a13910dea65a16f842b3c4bbbdb69029f10d89e9bd4e42fd82d73
+size 1677344


### PR DESCRIPTION

###submit to github
1) has add to full_cases.txt
2) Pr Info:
2.1) tpu-mlir bm1684x performance in stat.csv:
name,shape,gops,time(ms),mac_utilization,cpu_usage,ddr_utilization
dbnet_bm1684x_Bf16,2x3x736x1280,5.255,22.638,11.41%,2.00%,35.18%
dbnet_bm1684x_f16,2x3x736x1280,5.255,22.798,11.53%,2.00%,35.20%
dbnet_bm1684x_f32,2x3x736x1280,5.255,157.368,1.67%,5.00%,12.50%
compilation,2x3x736x1280,5.255,22.808,N/A,2.00%,N/A
compilation,2x3x736x1280,5.255,22.804,N/A,2.00%,N/A
compilation,2x3x736x1280,5.255,22.804,N/A,2.00%,N/A
fp32:flops: 92343593768, runtime: 99.522163ms, ComputationAbility: 0.927870T
fp16:flops: 92343593768, runtime: 19.114132ms, ComputationAbility: 4.831169T
bf16:flops: 65554824720, runtime: 21.997709ms, ComputationAbility: 2.980075T
2.2)tpu-mlir bm1684 performace in stat.csv
name,shape,gops,time(ms),mac_utilization,cpu_usage,ddr_utilization
dbnet_bm1684_f32,,5.255,nan,nan%,0.00%,nan%
compilation,,5.255,nan,N/A,0.00%,N/A
fp32:flops: 92343593768, runtime: 138.740356ms, ComputationAbility: 0.665586T
2.2)tpu-mlir:
branch:master
commit id: cb3736f7759f28ba6e91911cfce3a6a8ab52ae1a
2.3)libsophon:0.4.5
2.4)tpu-nntc:
branch:Release
commit id: 315ccc9a5ba3b401039e399fd6f8cdc92f70c78b
2.5) tpu-nntc bm1684x performance in stat.csv:
name,shape,gops,time(ms),mac_utilization,cpu_usage,ddr_utilization
fp32:flops: 52233002534, runtime: 57.945896ms, ComputationAbility: 0.901410T
int8:flops: 52254391204, runtime: 7.832151ms, ComputationAbility: 6.671781T