### PR TITLE
updata onet.mlir.config.yaml && add 4batch config

### DIFF
--- a/vision/detection/mtcnn/onet.mlir.config.yaml
+++ b/vision/detection/mtcnn/onet.mlir.config.yaml
@@ -1,10 +1,11 @@
 ---
 
 name: mtcnn_onet
-gops: 0.0262
+gops: [0.0262, 0.105]
 
 shapes:
   - [1, 3, 48, 48]
+  - [4, 3, 48, 48]
 
 mlir_transform:
   model_transform.py
@@ -27,28 +28,27 @@ deploy:
   - model_deploy.py  --mlir $(workdir)/$(name).mlir
     --quantize INT8
     --calibration_table $(home)/det3_cali_table
-    --quantize_table $(home)/qtable.txt
     --quant_input
     --quant_output
     --chip $(target)
     --test_input $(workdir)/$(name)_in_f32.npz
     --test_reference $(name)_top_outputs.npz
-    --tolerance 0.82,0.30
+    --tolerance 0.75,0.25
     --model $(workdir)/$(name)_$(target)_int8_sym.bmodel
 
 BM1684X:
   +deploy:
-    - model_deploy.py --mlir $(workdir)/$(name).mlir
+    - model_deploy.py  --mlir $(workdir)/$(name).mlir
         --quantize F16
         --chip $(target)
         --test_input $(workdir)/$(name)_in_f32.npz
         --test_reference $(name)_top_outputs.npz
         --tolerance 0.95,0.85
-        --model $(workdir)/$(name)_$(target)_f16.bmodel
-    - model_deploy.py --mlir $(workdir)/$(name).mlir
+        --model $(workdir)/$(name)_bm1684x_f16.bmodel
+    - model_deploy.py  --mlir $(workdir)/$(name).mlir
         --quantize BF16
         --chip $(target)
         --test_input $(workdir)/$(name)_in_f32.npz
         --test_reference $(name)_top_outputs.npz
         --tolerance 0.95,0.85
-        --model $(workdir)/$(name)_$(target)_bf16.bmodel
+        --model $(workdir)/$(name)_bm1684x_bf16.bmodel

--- a/vision/detection/mtcnn/onet.nntc.config.yaml
+++ b/vision/detection/mtcnn/onet.nntc.config.yaml
@@ -16,6 +16,7 @@ fp_compile_options:
   --target $(target)
   --opt 1
   --cmp 1
+  --enable_profile=True
 
 time_only_cali:
   python3 -m ufw.cali.cali_model

--- a/vision/detection/mtcnn/pnet.mlir.config.yaml
+++ b/vision/detection/mtcnn/pnet.mlir.config.yaml
@@ -1,10 +1,11 @@
 ---
 
 name: mtcnn_pnet
-gops: 0.000095
+gops: [0.000095, 0.00037]
 
 shapes:
   - [1, 3, 12, 12]
+  - [4, 3, 12, 12]
 
 mlir_transform:
   model_transform.py
@@ -18,22 +19,22 @@ mlir_transform:
 
 deploy:
   - model_deploy.py  --mlir $(workdir)/$(name).mlir
-    --quantize F32
-    --chip $(target)
-    --test_input $(workdir)/$(name)_in_f32.npz
-    --test_reference $(name)_top_outputs.npz
-    --tolerance 0.99,0.99
-    --model $(workdir)/$(name)_$(target)_f32.bmodel
+      --quantize F32
+      --chip $(target)
+      --test_input $(workdir)/$(name)_in_f32.npz
+      --test_reference $(name)_top_outputs.npz
+      --tolerance 0.99,0.99
+      --model $(workdir)/$(name)_$(target)_f32.bmodel
   - model_deploy.py  --mlir $(workdir)/$(name).mlir
-    --quantize INT8
-    --calibration_table $(home)/det1_cali_table
-    --quant_input
-    --quant_output
-    --chip $(target)
-    --test_input $(workdir)/$(name)_in_f32.npz
-    --test_reference $(name)_top_outputs.npz
-    --tolerance 0.88,0.26
-    --model $(workdir)/$(name)_$(target)_int8_sym.bmodel
+      --quantize INT8
+      --calibration_table $(home)/det1_cali_table
+      --quant_input
+      --quant_output
+      --chip $(target)
+      --test_input $(workdir)/$(name)_in_f32.npz
+      --test_reference $(name)_top_outputs.npz
+      --tolerance 0.88,0.29
+      --model $(workdir)/$(name)_$(target)_int8_sym.bmodel
 
 BM1684X:
   +deploy:
@@ -43,11 +44,11 @@ BM1684X:
         --test_input $(workdir)/$(name)_in_f32.npz
         --test_reference $(name)_top_outputs.npz
         --tolerance 0.95,0.85
-        --model $(workdir)/$(name)_$(target)_f16.bmodel
+        --model $(workdir)/$(name)_bm1684x_f16.bmodel
     - model_deploy.py --mlir $(workdir)/$(name).mlir
         --quantize BF16
         --chip $(target)
         --test_input $(workdir)/$(name)_in_f32.npz
         --test_reference $(name)_top_outputs.npz
         --tolerance 0.95,0.85
-        --model $(workdir)/$(name)_$(target)_bf16.bmodel
+        --model $(workdir)/$(name)_bm1684x_bf16.bmodel

--- a/vision/detection/mtcnn/pnet.nntc.config.yaml
+++ b/vision/detection/mtcnn/pnet.nntc.config.yaml
@@ -16,6 +16,7 @@ fp_compile_options:
   --target $(target)
   --opt 1
   --cmp 1
+  --enable_profile=True
 
 time_only_cali:
   python3 -m ufw.cali.cali_model

--- a/vision/detection/mtcnn/qtable.txt
+++ b/vision/detection/mtcnn/qtable.txt
@@ -1,2 +1,0 @@
-conv4 F32
-conv5 F32

--- a/vision/detection/mtcnn/rnet.mlir.config.yaml
+++ b/vision/detection/mtcnn/rnet.mlir.config.yaml
@@ -1,10 +1,11 @@
 ---
 
 name: mtcnn_rnet
-gops: 0.003
+gops: [0.003, 0.012]
 
 shapes:
   - [1, 3, 24, 24]
+  - [4, 3, 24, 24]
 
 mlir_transform:
   model_transform.py
@@ -18,36 +19,35 @@ mlir_transform:
 
 deploy:
   - model_deploy.py  --mlir $(workdir)/$(name).mlir
-    --quantize F32
-    --chip $(target)
-    --test_input $(workdir)/$(name)_in_f32.npz
-    --test_reference $(name)_top_outputs.npz
-    --tolerance 0.99,0.99
-    --model $(workdir)/$(name)_$(target)_f32.bmodel
+      --quantize F32
+      --chip $(target)
+      --test_input $(workdir)/$(name)_in_f32.npz
+      --test_reference $(name)_top_outputs.npz
+      --tolerance 0.99,0.99
+      --model $(workdir)/$(name)_$(target)_f32.bmodel
   - model_deploy.py  --mlir $(workdir)/$(name).mlir
-    --quantize INT8
-    --calibration_table $(home)/det2_cali_table
-    --quant_input
-    --quant_output
-    --chip $(target)
-    --test_input $(workdir)/$(name)_in_f32.npz
-    --test_reference $(name)_top_outputs.npz
-    --tolerance 0.93,0.50
-    --model $(workdir)/$(name)_$(target)_int8_sym.bmodel
+      --quantize INT8
+      --calibration_table $(home)/det2_cali_table
+      --quant_input
+      --quant_output
+      --chip $(target)
+      --test_input $(workdir)/$(name)_in_f32.npz
+      --test_reference $(name)_top_outputs.npz
+      --model $(workdir)/$(name)_$(target)_int8_sym.bmodel
 
 BM1684X:
   +deploy:
-    - model_deploy.py --mlir $(workdir)/$(name).mlir
+    - model_deploy.py  --mlir $(workdir)/$(name).mlir
         --quantize F16
         --chip $(target)
         --test_input $(workdir)/$(name)_in_f32.npz
         --test_reference $(name)_top_outputs.npz
         --tolerance 0.95,0.85
-        --model $(workdir)/$(name)_$(target)_f16.bmodel
-    - model_deploy.py --mlir $(workdir)/$(name).mlir
+        --model $(workdir)/$(name)_bm1684x_f16.bmodel
+    - model_deploy.py  --mlir $(workdir)/$(name).mlir
         --quantize BF16
         --chip $(target)
         --test_input $(workdir)/$(name)_in_f32.npz
         --test_reference $(name)_top_outputs.npz
         --tolerance 0.95,0.85
-        --model $(workdir)/$(name)_$(target)_bf16.bmodel
+        --model $(workdir)/$(name)_bm1684x_bf16.bmodel

--- a/vision/detection/mtcnn/rnet.nntc.config.yaml
+++ b/vision/detection/mtcnn/rnet.nntc.config.yaml
@@ -16,6 +16,7 @@ fp_compile_options:
   --target $(target)
   --opt 1
   --cmp 1
+  --enable_profile=True
 
 time_only_cali:
   python3 -m ufw.cali.cali_model


### PR DESCRIPTION
1) performance in stat.csv:
name,shape,gops,time(ms),mac_utilization,cpu_usage,ddr_utilization
mtcnn_rnet_bm1684_f32,1x3x24x24,3.000e-03,0.132,1.03%,8.00%,9.16%
mtcnn_rnet_bm1684_int8_sym,1x3x24x24,3.000e-03,0.150,0.11%,8.00%,2.19%
compilation,1x3x24x24,3.000e-03,0.137,N/A,1.00%,N/A
compilation,1x3x24x24,3.000e-03,0.129,N/A,2.00%,N/A
mtcnn_rnet_bm1684_f32,4x3x24x24,1.200e-02,0.168,3.25%,6.00%,7.94%
mtcnn_rnet_bm1684_int8_sym,4x3x24x24,1.200e-02,0.160,0.43%,7.00%,2.49%
compilation,4x3x24x24,1.200e-02,0.156,N/A,2.00%,N/A
compilation,4x3x24x24,1.200e-02,0.167,N/A,2.00%,N/A
mtcnn_onet_bm1684_f32,1x3x48x48,2.620e-02,0.218,5.46%,5.00%,21.34%
mtcnn_onet_bm1684_int8_sym,1x3x48x48,2.620e-02,0.218,0.68%,6.00%,5.71%
compilation,1x3x48x48,2.620e-02,0.218,N/A,2.00%,N/A
compilation,1x3x48x48,2.620e-02,0.210,N/A,2.00%,N/A
mtcnn_onet_bm1684_f32,4x3x48x48,0.105,0.368,12.95%,3.00%,13.66%
mtcnn_onet_bm1684_int8_sym,4x3x48x48,0.105,0.260,2.29%,5.00%,5.79%
compilation,4x3x48x48,0.105,0.366,N/A,2.00%,N/A
compilation,4x3x48x48,0.105,0.252,N/A,2.00%,N/A
mtcnn_pnet_bm1684_f32,1x3x12x12,9.500e-05,0.101,0.04%,9.00%,0.82%
mtcnn_pnet_bm1684_int8_sym,1x3x12x12,9.500e-05,0.121,0.00%,8.00%,0.22%
compilation,1x3x12x12,9.500e-05,0.102,N/A,2.00%,N/A
compilation,1x3x12x12,9.500e-05,0.122,N/A,2.00%,N/A
mtcnn_pnet_bm1684_f32,4x3x12x12,3.700e-04,0.106,0.16%,9.00%,0.93%
mtcnn_pnet_bm1684_int8_sym,4x3x12x12,3.700e-04,0.123,0.02%,8.00%,0.34%
compilation,4x3x12x12,3.700e-04,0.109,N/A,1.00%,N/A
compilation,4x3x12x12,3.700e-04,0.122,N/A,2.00%,N/A

onet fp32 1batch : flops: 26236858, runtime: 0.091931ms, ComputationAbility: 0.285398T
onet int8  1batch:  flops: 26236858, runtime: 0.057858ms, ComputationAbility: 0.453468T
onet fp32 4batch : flops: 104947432, runtime: 0.194745ms, ComputationAbility: 0.538895T
onet int8  4batch:  flops: 104947432, runtime: 0.094584ms, ComputationAbility: 1.109573T

pnet fp32 1batch : flops: 92888, runtime: 0.006324ms, ComputationAbility: 0.014689T
pnet int8  1batch:  flops: 92888, runtime: 0.005933ms, ComputationAbility: 0.015657T
pnet fp32 4batch : flops: 371552, runtime: 0.008882ms, ComputationAbility: 0.041833T
pnet int8  4batch:  flops: 371552, runtime: 0.006587ms, ComputationAbility: 0.056405T

rnet fp32 1batch : flops: 3135244, runtime: 0.028425ms, ComputationAbility: 0.110297T
rnet int8  1batch:  flops: 3135244, runtime: 0.019733ms, ComputationAbility: 0.158885T
rnet fp32 4batch : flops: 12540976, runtime: 0.053729ms, ComputationAbility: 0.233411T
rnet int8  4batch:  flops: 12540976, runtime: 0.034535ms, ComputationAbility: 0.363143T

2) 驱动版本号及工具链版本信息
2.1) libsophon:0.4.5
2.2) tpu-mlir 
branch:master
commit id: 3315cb45
