### PR TITLE
add 84-Retinaface-mlir

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ python3 .github/workflows/check.py
 |ResNet50\_vd\_infer              |[vision/classification/ResNet50\_vd\_paddle](vision/classification/ResNet50_vd_paddle)                |                    |:white\_check\_mark:|
 |resnext                          |[vision/classification/ResNeXt](vision/classification/ResNeXt)                                        |:white\_check\_mark:|                    |
 |resneXt50                        |[vision/classification/ResNeXt50](vision/classification/ResNeXt50)                                    |:white\_check\_mark:|                    |
-|retinaface                       |[vision/detection/retinaface](vision/detection/retinaface)                                            |:white\_check\_mark:|                    |
+|retinaface                       |[vision/detection/retinaface](vision/detection/retinaface)                                            |:white\_check\_mark:|:white\_check\_mark:|
 |scrfd                            |[vision/detection/scrfd](vision/detection/scrfd)                                                      |                    |:white\_check\_mark:|
 |SegFormer                        |[vision/segmentation/SegFormer](vision/segmentation/SegFormer)                                        |                    |:white\_check\_mark:|
 |shufflenet\_v2                   |[vision/classification/shufflenet\_v2](vision/classification/shufflenet_v2)                           |                    |:white\_check\_mark:|

--- a/vision/detection/retinaface/mlir.config.yaml
+++ b/vision/detection/retinaface/mlir.config.yaml
@@ -1,0 +1,41 @@
+---
+
+name: retinaface
+gops: 88.7
+
+shapes:
+  - [1, 3, 640, 640]
+
+mlir_transform:
+  model_transform.py
+    --model_name $(name)
+    --model_def $(home)/retinaface.onnx
+    --test_input $(root)/dataset/samples/cat.jpg
+    --input_shapes [$(shape_param)]
+    --test_result $(name)_top_outputs.npz
+    --mlir $(workdir)/$(name).mlir
+
+mlir_calibration:
+  run_calibration.py $(workdir)/$(name).mlir
+    --dataset $(coco2017_mlir_cali_set)
+    --input_num 100
+    -o $(home)/cali_table
+
+BM1684:
+  deploy:
+    - model_deploy.py  --mlir $(workdir)/$(name).mlir
+        --quantize F32
+        --chip $(target)
+        --test_input $(workdir)/$(name)_in_f32.npz
+        --test_reference $(name)_top_outputs.npz
+        --tolerance 0.99,0.99
+        --model $(workdir)/$(name)_$(target)_f32.bmodel
+    - model_deploy.py  --mlir $(workdir)/$(name).mlir
+        --quantize INT8
+        --calibration_table $(home)/cali_table
+        --quant_input
+        --quant_output
+        --chip $(target)
+        --test_input $(workdir)/$(name)_in_f32.npz
+        --test_reference $(name)_top_outputs.npz
+        --model $(workdir)/$(name)_bm1684_int8_sym.bmodel

--- a/vision/detection/retinaface/nntc.config.yaml
+++ b/vision/detection/retinaface/nntc.config.yaml
@@ -3,6 +3,8 @@ name: retinaface
 gops: 88.6
 model: $(home)/retinaface.onnx
 
+runtime_cmp: false
+
 BM1684X:
   fp_loops:
     - build_env: [ ]


### PR DESCRIPTION
1) performance in stat.csv:
name,shape,gops,time(ms),mac_utilization,cpu_usage,ddr_utilization
retinaface_bm1684_f32,1x3x640x640,2.620e-02,58.603,0.02%,6.00%,28.37%
retinaface_bm1684_int8_sym,1x3x640x640,2.620e-02,42.244,0.00%,2.00%,43.14%
compilation,1x3x640x640,2.620e-02,42.208,N/A,3.00%,N/A
compilation,1x3x640x640,2.620e-02,58.688,N/A,6.00%,N/A

onet fp32 flops: 88777652800, runtime: 53.136700ms, ComputationAbility: 1.670741T
onet int8  flops: 88777652800, runtime: 39.714249ms, ComputationAbility: 2.235411T

2) 驱动版本号及工具链版本信息
2.1) libsophon:0.4.6
2.2) tpu-mlir 
branch:master
commit id: 10e517e7e7df33535e8a001bd218820df3dc77a2
