### PR TITLE
add 84-mlir-yoloface

### DIFF
--- a/vision/detection/yoloface/mlir.config.yaml
+++ b/vision/detection/yoloface/mlir.config.yaml
@@ -25,31 +25,32 @@ mlir_calibration:
     --input_num 100
     -o $(home)/cali_table
 
+deploy:
+  - model_deploy.py  --mlir $(workdir)/transformed.mlir
+      --quantize F32
+      --chip $(target)
+      --test_input $(workdir)/$(name)_in_f32.npz
+      --test_reference $(name)_top_outputs.npz
+      --tolerance 0.99,0.99
+      --model $(workdir)/$(name)_$(target)_f32.bmodel
+  - model_deploy.py --mlir $(workdir)/transformed.mlir
+      --quantize INT8
+      --calibration_table $(home)/cali_table
+      --quant_input
+      --quant_output
+      --chip $(target)
+      --test_input $(workdir)/$(name)_in_f32.npz
+      --test_reference $(name)_top_outputs.npz
+      --tolerance 0.85,0.45
+      --model $(workdir)/$(name)_$(target)_int8_sym.bmodel
 BM1684X:
-  deploy:
-    - model_deploy.py  --mlir $(workdir)/transformed.mlir
-        --quantize F32
-        --chip bm1684x
-        --test_input $(workdir)/$(name)_in_f32.npz
-        --test_reference $(name)_top_outputs.npz
-        --tolerance 0.99,0.99
-        --model $(workdir)/$(name)_bm1684x_f32.bmodel
-    - model_deploy.py --mlir $(workdir)/transformed.mlir
-        --quantize INT8
-        --calibration_table $(home)/cali_table
-        --quant_input
-        --quant_output
-        --chip bm1684x
-        --test_input $(workdir)/$(name)_in_f32.npz
-        --test_reference $(name)_top_outputs.npz
-        --tolerance 0.85,0.45
-        --model $(workdir)/$(name)_bm1684x_int8_sym.bmodel
+  +deploy:
     - model_deploy.py --mlir $(workdir)/transformed.mlir
       --quantize INT8
       --asymmetric
       --calibration_table $(home)/cali_table
-      --chip bm1684x
+      --chip $(target)
       --test_input $(workdir)/$(name)_in_f32.npz
       --test_reference $(name)_top_outputs.npz
       --tolerance 0.90,0.55
-      --model $(workdir)/$(name)_bm1684x_int8_asym.bmodel
+      --model $(workdir)/$(name)_$(target)_int8_asym.bmodel


### PR DESCRIPTION
1) performance in stat.csv:
name,shape,gops,time(ms),mac_utilization,cpu_usage,ddr_utilization
tpu-mlir_yoloface_bm1684_f32,1x3x736x736,7.600,23.809,14.51%,1.00%,28.17%
tpu-mlir_yoloface_bm1684_int8_sym,1x3x736x736,7.600,13.995,3.09%,1.00%,46.87%
compilation,1x3x736x736,7.600,23.770,N/A,5.00%,N/A
compilation,1x3x736x736,7.600,14.010,N/A,1.00%,N/A

onet fp32 flops: 7600257264, runtime: 19.729139ms, ComputationAbility: 0.385230T
onet int8  flops: 7600257264, runtime: 11.194795ms, ComputationAbility: 0.678910T

2) 驱动版本号及工具链版本信息
2.1) libsophon:0.4.6
2.2) tpu-mlir 
branch:master
commit id: 10e517e7e7df33535e8a001bd218820df3dc77a2
