### PR TITLE
add deeplabv3p 1684 mlir

### DIFF
--- a/vision/segmentation/deeplabv3p/data/deeplabv3p_in_f32.npz
+++ b/vision/segmentation/deeplabv3p/data/deeplabv3p_in_f32.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcfc02ecfdcfd925748043d2405d352fab2bdcda6769444815854d9a8f3ddffd
+size 2457856

--- a/vision/segmentation/deeplabv3p/mlir.config.yaml
+++ b/vision/segmentation/deeplabv3p/mlir.config.yaml
@@ -19,6 +19,12 @@ mlir_transform:
     --test_result $(name)_top_outputs.npz
     --mlir $(workdir)/transformed.mlir
 
+mlir_calibration:
+  run_calibration.py $(workdir)/transformed.mlir
+    --dataset $(home)/data
+    --input_num 1
+    -o $(workdir)/$(name).calitable
+
 BM1684X:
   deploy:
     - model_deploy.py  --mlir $(workdir)/transformed.mlir
@@ -28,3 +34,23 @@ BM1684X:
         --test_reference $(name)_top_outputs.npz
         --tolerance 0.99,0.99
         --model $(workdir)/$(name)_bm1684x_f32.bmodel
+
+BM1684:
+  deploy:
+    - model_deploy.py  --mlir $(workdir)/transformed.mlir
+        --quantize F32
+        --chip bm1684
+        --test_input $(workdir)/$(name)_in_f32.npz
+        --test_reference $(name)_top_outputs.npz
+        --tolerance 0.99,0.99
+        --model $(workdir)/$(name)_bm1684_f32.bmodel
+    - model_deploy.py --mlir $(workdir)/transformed.mlir
+        --quantize INT8
+        --calibration_table $(workdir)/$(name).calitable
+        --chip bm1684
+        --test_input $(workdir)/$(name)_in_f32.npz
+        --test_reference $(name)_top_outputs.npz
+        --tolerance 0.90,0.70
+        --quant_input
+        --quant_output
+        --model $(workdir)/$(name)_bm1684_int8_sym.bmodel


### PR DESCRIPTION
name		prec,	shape		gops	time(ms)	mac_utilization	ddr_utilization	cpu_usage
deeplabv3p	FP32	1x3x640x320	178.138	1684.676	4.81%			6.22%			11.00%
deeplabv3p	INT8	1x3x640x320	178.138	1094.195	0.93%			7.22%			10.00%

Driver Version: 0.4.6
TPU-MLIR: daily    tpu-mlir_v1.1.101-g52c640d2-20230601.tar.gz